### PR TITLE
Feature/Trade_lite_future_ws_event

### DIFF
--- a/v2/futures/client.go
+++ b/v2/futures/client.go
@@ -154,6 +154,7 @@ const (
 	UserDataEventTypeAccountUpdate       UserDataEventType = "ACCOUNT_UPDATE"
 	UserDataEventTypeOrderTradeUpdate    UserDataEventType = "ORDER_TRADE_UPDATE"
 	UserDataEventTypeAccountConfigUpdate UserDataEventType = "ACCOUNT_CONFIG_UPDATE"
+	UserDataEventTypeTradeLite           UserDataEventType = "TRADE_LITE"
 
 	UserDataEventReasonTypeDeposit             UserDataEventReasonType = "DEPOSIT"
 	UserDataEventReasonTypeWithdraw            UserDataEventReasonType = "WITHDRAW"

--- a/v2/futures/websocket_service.go
+++ b/v2/futures/websocket_service.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/bitly/go-simplejson"
 )
 
 // Endpoints
@@ -23,7 +25,19 @@ var (
 	WebsocketKeepalive = false
 	// UseTestnet switch all the WS streams from production to the testnet
 	UseTestnet = false
+	ProxyUrl   = ""
 )
+
+func getWsProxyUrl() *string {
+	if ProxyUrl == "" {
+		return nil
+	}
+	return &ProxyUrl
+}
+
+func SetWsProxyUrl(url string) {
+	ProxyUrl = url
+}
 
 // getWsEndpoint return the base endpoint of the WS according the UseTestnet flag
 func getWsEndpoint() string {
@@ -368,8 +382,8 @@ type WsContinuousKline struct {
 	ActiveBuyQuoteVolume string `json:"Q"`
 }
 
-// WsContinuousKlineSubcribeArgs used with WsContinuousKlineServe or WsCombinedContinuousKlineServe
-type WsContinuousKlineSubcribeArgs struct {
+// WsContinuousKlineSubscribeArgs used with WsContinuousKlineServe or WsCombinedContinuousKlineServe
+type WsContinuousKlineSubscribeArgs struct {
 	Pair         string
 	ContractType string
 	Interval     string
@@ -379,7 +393,7 @@ type WsContinuousKlineSubcribeArgs struct {
 type WsContinuousKlineHandler func(event *WsContinuousKlineEvent)
 
 // WsContinuousKlineServe serve websocket continuous kline handler with a pair and contractType and interval like 15m, 30s
-func WsContinuousKlineServe(subscribeArgs *WsContinuousKlineSubcribeArgs, handler WsContinuousKlineHandler,
+func WsContinuousKlineServe(subscribeArgs *WsContinuousKlineSubscribeArgs, handler WsContinuousKlineHandler,
 	errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
 	endpoint := fmt.Sprintf("%s/%s_%s@continuousKline_%s", getWsEndpoint(), strings.ToLower(subscribeArgs.Pair),
 		strings.ToLower(subscribeArgs.ContractType), subscribeArgs.Interval)
@@ -397,7 +411,7 @@ func WsContinuousKlineServe(subscribeArgs *WsContinuousKlineSubcribeArgs, handle
 }
 
 // WsCombinedContinuousKlineServe is similar to WsContinuousKlineServe, but it handles multiple pairs of different contractType with its interval
-func WsCombinedContinuousKlineServe(subscribeArgsList []*WsContinuousKlineSubcribeArgs,
+func WsCombinedContinuousKlineServe(subscribeArgsList []*WsContinuousKlineSubscribeArgs,
 	handler WsContinuousKlineHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
 	endpoint := getCombinedEndpoint()
 	for _, val := range subscribeArgsList {
@@ -559,6 +573,11 @@ type WsBookTickerEvent struct {
 	BestAskQty      string `json:"A"`
 }
 
+type WsCombinedBookTickerEvent struct {
+	Data   *WsBookTickerEvent `json:"data"`
+	Stream string             `json:"stream"`
+}
+
 // WsBookTickerHandler handle websocket that pushes updates to the best bid or ask price or quantity in real-time for a specified symbol.
 type WsBookTickerHandler func(event *WsBookTickerEvent)
 
@@ -574,6 +593,25 @@ func WsBookTickerServe(symbol string, handler WsBookTickerHandler, errHandler Er
 			return
 		}
 		handler(event)
+	}
+	return wsServe(cfg, wsHandler, errHandler)
+}
+
+func WsCombinedBookTickerServe(symbols []string, handler WsBookTickerHandler, errHandler ErrHandler) (doneC, stopC chan struct{}, err error) {
+	endpoint := getCombinedEndpoint()
+	for _, s := range symbols {
+		endpoint += fmt.Sprintf("%s@bookTicker", strings.ToLower(s)) + "/"
+	}
+	endpoint = endpoint[:len(endpoint)-1]
+	cfg := newWsConfig(endpoint)
+	wsHandler := func(message []byte) {
+		event := new(WsCombinedBookTickerEvent)
+		err := json.Unmarshal(message, event)
+		if err != nil {
+			errHandler(err)
+			return
+		}
+		handler(event.Data)
 	}
 	return wsServe(cfg, wsHandler, errHandler)
 }
@@ -958,14 +996,106 @@ func WsCompositiveIndexServe(symbol string, handler WsCompositeIndexHandler, err
 
 // WsUserDataEvent define user data event
 type WsUserDataEvent struct {
-	Event               UserDataEventType     `json:"e"`
-	Time                int64                 `json:"E"`
-	CrossWalletBalance  string                `json:"cw"`
-	MarginCallPositions []WsPosition          `json:"p"`
-	TransactionTime     int64                 `json:"T"`
-	AccountUpdate       WsAccountUpdate       `json:"a"`
-	OrderTradeUpdate    WsOrderTradeUpdate    `json:"o"`
+	Event           UserDataEventType `json:"e"`
+	Time            int64             `json:"E"`
+	TransactionTime int64             `json:"T"`
+
+	// listenKeyExpired only have Event and Time
+	//
+
+	// MARGIN_CALL
+	WsUserDataMarginCall
+
+	// ACCOUNT_UPDATE
+	WsUserDataAccountUpdate
+
+	// ORDER_TRADE_UPDATE
+	WsUserDataOrderTradeUpdate
+
+	// ACCOUNT_CONFIG_UPDATE
+	WsUserDataAccountConfigUpdate
+
+	// TRADE_LITE
+	WsUserDataTradeLite
+}
+
+type WsUserDataAccountConfigUpdate struct {
 	AccountConfigUpdate WsAccountConfigUpdate `json:"ac"`
+}
+
+type WsUserDataAccountUpdate struct {
+	AccountUpdate WsAccountUpdate `json:"a"`
+}
+
+type WsUserDataMarginCall struct {
+	CrossWalletBalance  string       `json:"cw"`
+	MarginCallPositions []WsPosition `json:"p"`
+}
+
+type WsUserDataOrderTradeUpdate struct {
+	OrderTradeUpdate WsOrderTradeUpdate `json:"o"`
+}
+
+type WsUserDataTradeLite struct {
+	Symbol          string   `json:"s"`
+	OriginalQty     string   `json:"q"`
+	OriginalPrice   string   //`json:"p"`
+	IsMaker         bool     `json:"m"`
+	ClientOrderID   string   `json:"c"`
+	Side            SideType `json:"S"`
+	LastFilledPrice string   `json:"L"`
+	LastFilledQty   string   `json:"l"`
+	TradeID         int64    `json:"t"`
+	OrderID         int64    `json:"i"`
+}
+
+func (w *WsUserDataTradeLite) fromSimpleJson(j *simplejson.Json) (err error) {
+	w.Symbol = j.Get("s").MustString()
+	w.OriginalQty = j.Get("q").MustString()
+	w.OriginalPrice = j.Get("p").MustString()
+	w.IsMaker = j.Get("m").MustBool()
+	w.ClientOrderID = j.Get("c").MustString()
+	w.Side = SideType(j.Get("S").MustString())
+	w.LastFilledPrice = j.Get("L").MustString()
+	w.LastFilledQty = j.Get("l").MustString()
+	w.TradeID = j.Get("t").MustInt64()
+	w.OrderID = j.Get("i").MustInt64()
+	return nil
+}
+
+func (e *WsUserDataEvent) UnmarshalJSON(data []byte) error {
+	j, err := newJSON(data)
+	if err != nil {
+		return err
+	}
+	e.Event = UserDataEventType(j.Get("e").MustString())
+	e.Time = j.Get("E").MustInt64()
+	if v, ok := j.CheckGet("T"); ok {
+		e.TransactionTime = v.MustInt64()
+	}
+
+	eventMaps := map[UserDataEventType]any{
+		UserDataEventTypeMarginCall:          &e.WsUserDataMarginCall,
+		UserDataEventTypeAccountUpdate:       &e.WsUserDataAccountUpdate,
+		UserDataEventTypeOrderTradeUpdate:    &e.WsUserDataOrderTradeUpdate,
+		UserDataEventTypeAccountConfigUpdate: &e.WsUserDataAccountConfigUpdate,
+	}
+
+	switch e.Event {
+	case UserDataEventTypeTradeLite:
+		return e.WsUserDataTradeLite.fromSimpleJson(j)
+	case UserDataEventTypeListenKeyExpired:
+		// noting
+	default:
+		if v, ok := eventMaps[e.Event]; ok {
+			if err := json.Unmarshal(data, v); err != nil {
+				return err
+			}
+		} else {
+			return fmt.Errorf("unexpected event type: %v", e.Event)
+		}
+	}
+	return nil
 }
 
 // WsAccountUpdate define account update
@@ -999,36 +1129,40 @@ type WsPosition struct {
 
 // WsOrderTradeUpdate define order trade update
 type WsOrderTradeUpdate struct {
-	Symbol               string             `json:"s"`
-	ClientOrderID        string             `json:"c"`
-	Side                 SideType           `json:"S"`
-	Type                 OrderType          `json:"o"`
-	TimeInForce          TimeInForceType    `json:"f"`
-	OriginalQty          string             `json:"q"`
-	OriginalPrice        string             `json:"p"`
-	AveragePrice         string             `json:"ap"`
-	StopPrice            string             `json:"sp"`
-	ExecutionType        OrderExecutionType `json:"x"`
-	Status               OrderStatusType    `json:"X"`
-	ID                   int64              `json:"i"`
-	LastFilledQty        string             `json:"l"`
-	AccumulatedFilledQty string             `json:"z"`
-	LastFilledPrice      string             `json:"L"`
-	CommissionAsset      string             `json:"N"`
-	Commission           string             `json:"n"`
-	TradeTime            int64              `json:"T"`
-	TradeID              int64              `json:"t"`
-	BidsNotional         string             `json:"b"`
-	AsksNotional         string             `json:"a"`
-	IsMaker              bool               `json:"m"`
-	IsReduceOnly         bool               `json:"R"`
-	WorkingType          WorkingType        `json:"wt"`
-	OriginalType         OrderType          `json:"ot"`
-	PositionSide         PositionSideType   `json:"ps"`
-	IsClosingPosition    bool               `json:"cp"`
-	ActivationPrice      string             `json:"AP"`
-	CallbackRate         string             `json:"cr"`
-	RealizedPnL          string             `json:"rp"`
+	Symbol               string             `json:"s"`   // Symbol
+	ClientOrderID        string             `json:"c"`   // Client order ID
+	Side                 SideType           `json:"S"`   // Side
+	Type                 OrderType          `json:"o"`   // Order type
+	TimeInForce          TimeInForceType    `json:"f"`   // Time in force
+	OriginalQty          string             `json:"q"`   // Original quantity
+	OriginalPrice        string             `json:"p"`   // Original price
+	AveragePrice         string             `json:"ap"`  // Average price
+	StopPrice            string             `json:"sp"`  // Stop price. Please ignore with TRAILING_STOP_MARKET order
+	ExecutionType        OrderExecutionType `json:"x"`   // Execution type
+	Status               OrderStatusType    `json:"X"`   // Order status
+	ID                   int64              `json:"i"`   // Order ID
+	LastFilledQty        string             `json:"l"`   // Order Last Filled Quantity
+	AccumulatedFilledQty string             `json:"z"`   // Order Filled Accumulated Quantity
+	LastFilledPrice      string             `json:"L"`   // Last Filled Price
+	CommissionAsset      string             `json:"N"`   // Commission Asset, will not push if no commission
+	Commission           string             `json:"n"`   // Commission, will not push if no commission
+	TradeTime            int64              `json:"T"`   // Order Trade Time
+	TradeID              int64              `json:"t"`   // Trade ID
+	BidsNotional         string             `json:"b"`   // Bids Notional
+	AsksNotional         string             `json:"a"`   // Asks Notional
+	IsMaker              bool               `json:"m"`   // Is this trade the maker side?
+	IsReduceOnly         bool               `json:"R"`   // Is this reduce only
+	WorkingType          WorkingType        `json:"wt"`  // Stop Price Working Type
+	OriginalType         OrderType          `json:"ot"`  // Original Order Type
+	PositionSide         PositionSideType   `json:"ps"`  // Position Side
+	IsClosingPosition    bool               `json:"cp"`  // If Close-All, pushed with conditional order
+	ActivationPrice      string             `json:"AP"`  // Activation Price, only puhed with TRAILING_STOP_MARKET order
+	CallbackRate         string             `json:"cr"`  // Callback Rate, only puhed with TRAILING_STOP_MARKET order
+	PriceProtect         bool               `json:"pP"`  // If price protection is turned on
+	RealizedPnL          string             `json:"rp"`  // Realized Profit of the trade
+	STP                  string             `json:"V"`   // STP mode
+	PriceMode            string             `json:"pm"`  // Price match mode
+	GTD                  int64              `json:"gtd"` // TIF GTD order auto cancel time
 }
 
 // WsAccountConfigUpdate define account config update

--- a/v2/futures/websocket_service_test.go
+++ b/v2/futures/websocket_service_test.go
@@ -575,7 +575,7 @@ func (s *websocketServiceTestSuite) TestContinuousKlineServe() {
 	s.mockWsServe(data, errors.New(fakeErrMsg))
 	defer s.assertWsServe()
 
-	doneC, stopC, err := WsContinuousKlineServe(&WsContinuousKlineSubcribeArgs{
+	doneC, stopC, err := WsContinuousKlineServe(&WsContinuousKlineSubscribeArgs{
 		Pair:         "BTCUSDT",
 		ContractType: "PERPETUAL",
 		Interval:     "1m",
@@ -668,7 +668,7 @@ func (s *websocketServiceTestSuite) TestWsCombinedContinuousKlineServe() {
 	s.mockWsServe(data, errors.New(fakeErrMsg))
 	defer s.assertWsServe()
 
-	input := []*WsContinuousKlineSubcribeArgs{
+	input := []*WsContinuousKlineSubscribeArgs{
 		{
 			Pair:         "ETHBTC",
 			ContractType: "PERPETUAL",
@@ -1641,21 +1641,21 @@ func (s *websocketServiceTestSuite) TestWsUserDataServeMarginCall() {
 		]
 	}`)
 	expectedEvent := &WsUserDataEvent{
-		Event:              "MARGIN_CALL",
-		Time:               1587727187525,
-		CrossWalletBalance: "3.16812045",
-		MarginCallPositions: []WsPosition{
-			{
-				Symbol:                    "ETHUSDT",
-				Side:                      "LONG",
-				Amount:                    "1.327",
-				MarginType:                "CROSSED",
-				IsolatedWallet:            "0",
-				MarkPrice:                 "187.17127",
-				UnrealizedPnL:             "-1.166074",
-				MaintenanceMarginRequired: "1.614445",
-			},
-		},
+		Event: "MARGIN_CALL",
+		Time:  1587727187525,
+		WsUserDataMarginCall: WsUserDataMarginCall{CrossWalletBalance: "3.16812045",
+			MarginCallPositions: []WsPosition{
+				{
+					Symbol:                    "ETHUSDT",
+					Side:                      "LONG",
+					Amount:                    "1.327",
+					MarginType:                "CROSSED",
+					IsolatedWallet:            "0",
+					MarkPrice:                 "187.17127",
+					UnrealizedPnL:             "-1.166074",
+					MaintenanceMarginRequired: "1.614445",
+				},
+			}},
 	}
 	s.testWsUserDataServe(data, expectedEvent)
 }
@@ -1718,50 +1718,52 @@ func (s *websocketServiceTestSuite) TestWsUserDataServeAccountUpdate() {
 		Event:           "ACCOUNT_UPDATE",
 		Time:            1564745798939,
 		TransactionTime: 1564745798938,
-		AccountUpdate: WsAccountUpdate{
-			Reason: "ORDER",
-			Balances: []WsBalance{
-				{
-					Asset:              "USDT",
-					Balance:            "122624.12345678",
-					CrossWalletBalance: "100.12345678",
+		WsUserDataAccountUpdate: WsUserDataAccountUpdate{
+			AccountUpdate: WsAccountUpdate{
+				Reason: "ORDER",
+				Balances: []WsBalance{
+					{
+						Asset:              "USDT",
+						Balance:            "122624.12345678",
+						CrossWalletBalance: "100.12345678",
+					},
+					{
+						Asset:              "BNB",
+						Balance:            "1.00000000",
+						CrossWalletBalance: "0.00000000",
+					},
 				},
-				{
-					Asset:              "BNB",
-					Balance:            "1.00000000",
-					CrossWalletBalance: "0.00000000",
-				},
-			},
-			Positions: []WsPosition{
-				{
-					Symbol:              "BTCUSDT",
-					Amount:              "0",
-					EntryPrice:          "0.00000",
-					AccumulatedRealized: "200",
-					UnrealizedPnL:       "0",
-					MarginType:          "isolated",
-					IsolatedWallet:      "0.00000000",
-					Side:                "BOTH",
-				},
-				{
-					Symbol:              "BTCUSDT",
-					Amount:              "20",
-					EntryPrice:          "6563.66500",
-					AccumulatedRealized: "0",
-					UnrealizedPnL:       "2850.21200",
-					MarginType:          "isolated",
-					IsolatedWallet:      "13200.70726908",
-					Side:                "LONG",
-				},
-				{
-					Symbol:              "BTCUSDT",
-					Amount:              "-10",
-					EntryPrice:          "6563.86000",
-					AccumulatedRealized: "-45.04000000",
-					UnrealizedPnL:       "-1423.15600",
-					MarginType:          "isolated",
-					IsolatedWallet:      "6570.42511771",
-					Side:                "SHORT",
+				Positions: []WsPosition{
+					{
+						Symbol:              "BTCUSDT",
+						Amount:              "0",
+						EntryPrice:          "0.00000",
+						AccumulatedRealized: "200",
+						UnrealizedPnL:       "0",
+						MarginType:          "isolated",
+						IsolatedWallet:      "0.00000000",
+						Side:                "BOTH",
+					},
+					{
+						Symbol:              "BTCUSDT",
+						Amount:              "20",
+						EntryPrice:          "6563.66500",
+						AccumulatedRealized: "0",
+						UnrealizedPnL:       "2850.21200",
+						MarginType:          "isolated",
+						IsolatedWallet:      "13200.70726908",
+						Side:                "LONG",
+					},
+					{
+						Symbol:              "BTCUSDT",
+						Amount:              "-10",
+						EntryPrice:          "6563.86000",
+						AccumulatedRealized: "-45.04000000",
+						UnrealizedPnL:       "-1423.15600",
+						MarginType:          "isolated",
+						IsolatedWallet:      "6570.42511771",
+						Side:                "SHORT",
+					},
 				},
 			},
 		},
@@ -1811,37 +1813,39 @@ func (s *websocketServiceTestSuite) TestWsUserDataServeOrderTradeUpdate() {
 		Event:           "ORDER_TRADE_UPDATE",
 		Time:            1568879465651,
 		TransactionTime: 1568879465650,
-		OrderTradeUpdate: WsOrderTradeUpdate{
-			Symbol:               "BTCUSDT",
-			ClientOrderID:        "TEST",
-			Side:                 "SELL",
-			Type:                 "TRAILING_STOP_MARKET",
-			TimeInForce:          "GTC",
-			OriginalQty:          "0.001",
-			OriginalPrice:        "0",
-			AveragePrice:         "0",
-			StopPrice:            "7103.04",
-			ExecutionType:        "NEW",
-			Status:               "NEW",
-			ID:                   8886774,
-			LastFilledQty:        "0",
-			AccumulatedFilledQty: "0",
-			LastFilledPrice:      "0",
-			CommissionAsset:      "USDT",
-			Commission:           "0",
-			TradeTime:            1568879465651,
-			TradeID:              0,
-			BidsNotional:         "0",
-			AsksNotional:         "9.91",
-			IsMaker:              false,
-			IsReduceOnly:         false,
-			WorkingType:          "CONTRACT_PRICE",
-			OriginalType:         "TRAILING_STOP_MARKET",
-			PositionSide:         "LONG",
-			IsClosingPosition:    false,
-			ActivationPrice:      "7476.89",
-			CallbackRate:         "5.0",
-			RealizedPnL:          "0",
+		WsUserDataOrderTradeUpdate: WsUserDataOrderTradeUpdate{
+			OrderTradeUpdate: WsOrderTradeUpdate{
+				Symbol:               "BTCUSDT",
+				ClientOrderID:        "TEST",
+				Side:                 "SELL",
+				Type:                 "TRAILING_STOP_MARKET",
+				TimeInForce:          "GTC",
+				OriginalQty:          "0.001",
+				OriginalPrice:        "0",
+				AveragePrice:         "0",
+				StopPrice:            "7103.04",
+				ExecutionType:        "NEW",
+				Status:               "NEW",
+				ID:                   8886774,
+				LastFilledQty:        "0",
+				AccumulatedFilledQty: "0",
+				LastFilledPrice:      "0",
+				CommissionAsset:      "USDT",
+				Commission:           "0",
+				TradeTime:            1568879465651,
+				TradeID:              0,
+				BidsNotional:         "0",
+				AsksNotional:         "9.91",
+				IsMaker:              false,
+				IsReduceOnly:         false,
+				WorkingType:          "CONTRACT_PRICE",
+				OriginalType:         "TRAILING_STOP_MARKET",
+				PositionSide:         "LONG",
+				IsClosingPosition:    false,
+				ActivationPrice:      "7476.89",
+				CallbackRate:         "5.0",
+				RealizedPnL:          "0",
+			},
 		},
 	}
 	s.testWsUserDataServe(data, expectedEvent)
@@ -1861,11 +1865,51 @@ func (s *websocketServiceTestSuite) TestWsUserDataServeAccountConfigUpdate() {
 		Event:           "ACCOUNT_CONFIG_UPDATE",
 		Time:            1611646737479,
 		TransactionTime: 1611646737476,
-		AccountConfigUpdate: WsAccountConfigUpdate{
-			Symbol:   "BTCUSDT",
-			Leverage: 25,
+		WsUserDataAccountConfigUpdate: WsUserDataAccountConfigUpdate{
+			AccountConfigUpdate: WsAccountConfigUpdate{
+				Symbol:   "BTCUSDT",
+				Leverage: 25,
+			},
 		},
 	}
+	s.testWsUserDataServe(data, expectedEvent)
+}
+
+func (s *websocketServiceTestSuite) TestWsUserDataServeTradeLite() {
+	data := []byte(`{
+		"e":"TRADE_LITE",             
+		"E":1721895408092,            
+		"T":1721895408214,                                   
+		"s":"BTCUSDT",                
+		"q":"0.001",                  
+		"p":"0",                      
+		"m":false,                    
+		"c":"z8hcUoOsqEdKMeKPSABslD", 
+		"S":"BUY",                   
+		"L":"64089.20",              
+		"l":"0.040",                 
+		"t":109100866,               
+		"i":8886774                
+	}`)
+
+	expectedEvent := &WsUserDataEvent{
+		Event:           "TRADE_LITE",
+		Time:            1721895408092,
+		TransactionTime: 1721895408214,
+		WsUserDataTradeLite: WsUserDataTradeLite{
+			Symbol:          "BTCUSDT",
+			OriginalQty:     "0.001",
+			OriginalPrice:   "0",
+			IsMaker:         false,
+			ClientOrderID:   "z8hcUoOsqEdKMeKPSABslD",
+			Side:            "BUY",
+			LastFilledPrice: "64089.20",
+			LastFilledQty:   "0.040",
+			TradeID:         109100866,
+			OrderID:         8886774,
+		},
+	}
+
 	s.testWsUserDataServe(data, expectedEvent)
 }
 
@@ -1882,6 +1926,21 @@ func (s *websocketServiceTestSuite) assertUserDataEvent(e, a *WsUserDataEvent) {
 	s.assertAccountUpdate(e.AccountUpdate, a.AccountUpdate)
 	s.assertOrderTradeUpdate(e.OrderTradeUpdate, a.OrderTradeUpdate)
 	s.assertAccountConfigUpdate(e.AccountConfigUpdate, a.AccountConfigUpdate)
+	s.assertTradeLite(e.WsUserDataTradeLite, a.WsUserDataTradeLite)
+}
+
+func (s *websocketServiceTestSuite) assertTradeLite(e, a WsUserDataTradeLite) {
+	r := s.r()
+	r.Equal(e.Symbol, a.Symbol, "Symbol")
+	r.Equal(e.OriginalQty, a.OriginalQty, "OriginalQty")
+	r.Equal(e.OriginalPrice, a.OriginalPrice, "OriginalPrice")
+	r.Equal(e.IsMaker, a.IsMaker, "IsMaker")
+	r.Equal(e.ClientOrderID, a.ClientOrderID, "ClientOrderID")
+	r.Equal(e.Side, a.Side, "Side")
+	r.Equal(e.LastFilledPrice, a.LastFilledPrice, "LastFilledPrice")
+	r.Equal(e.LastFilledQty, a.LastFilledQty, "LastFilledQty")
+	r.Equal(e.TradeID, a.TradeID, "TradeID")
+	r.Equal(e.OrderID, a.OrderID, "OrderID")
 }
 
 func (s *websocketServiceTestSuite) assertPosition(e, a WsPosition) {


### PR DESCRIPTION
Binance introduced new event in userdata WS: https://www.binance.com/en/support/announcement/introducing-trade-lite-for-usd%E2%93%A2-m-futures-websocket-2024-09-03-f2809259702b46f7abdc9c97b977908f

https://developers.binance.com/docs/derivatives/usds-margined-futures/user-data-streams/Event-Trade-Lite

it's incompatible with our futures.WsUserDataEvent

type WsUserDataEvent struct {
    Event               UserDataEventType     `json:"e"`
    Time                int64                 `json:"E"`
    CrossWalletBalance  string                `json:"cw"`
    MarginCallPositions []WsPosition          `json:"p"`
    TransactionTime     int64                 `json:"T"`
    AccountUpdate       WsAccountUpdate       `json:"a"`
    OrderTradeUpdate    WsOrderTradeUpdate    `json:"o"`
    AccountConfigUpdate WsAccountConfigUpdate `json:"ac"`
}
error is
`json: cannot unmarshal string into Go struct field .p of type []futures.WsPosition`

Reference: https://github.com/adshao/go-binance/commit/4b74da2aea7db04251d655b3ac5c46f8d6ef5f68